### PR TITLE
tweak api, add linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ explictly public:
 ```js
 const explicitPublicMsg = {
   content: { type: 'profile' },
-  options: { allowPublic: true }
+  allowPublic: true
 }
 
 server.publish(explicitPublicMsg, (err, msg) => {

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ const caps = require('ssb-caps')
 
 
 const stack = Stack({ caps })
-  .use(require('ssb-db'))           // << required
-  .use(require('ssb-profile'))
+  .use(require('ssb-d2'))
   .use(require('ssb-recps-guard'))  // << must be last
 
 const config = {
@@ -28,9 +27,11 @@ const sever = stack(config)
 
 auto-blocked:
 ```js
-const unallowedMsg = { type: 'profile' }
+const unallowedMsg = {
+  content: { type: 'profile' }
+}
 
-server.publish(unallowedMsg, (err, msg) => {
+server.db.create(unallowedMsg, (err, msg) => {
   console.log(err)
   // => Error: recps-guard - no accidental public messages allowed!
 })
@@ -38,10 +39,12 @@ server.publish(unallowedMsg, (err, msg) => {
 
 config-allowed:
 ```js
-const allowedMsg = { type: 'contact' }
+const allowedMsg = {
+  content: { type: 'contact' }
+}
 // this type was allowed in our config (see above)
 
-server.publish(allowedType, (err, msg) => {
+server.db.create(allowedType, (err, msg) => {
   console.log(msg.value.content)
   // => { type: 'contact' }
 })
@@ -54,35 +57,23 @@ const explicitPublicMsg = {
   allowPublic: true
 }
 
-server.publish(explicitPublicMsg, (err, msg) => {
+server.db.create(explicitPublicMsg, (err, msg) => {
   console.log(msg.value.content)
   // => { type: 'profile' }
-
-  // NOTE: only `content` is published
-})
-
-// with ssb-db2's ssb.db.create, note different option format!
-const explicitPublicMsgDb2 = {
-  content: { type: 'profile' },
-  allowPublic: true
-}
-
-server.db.create(explicitPublicMsgDb2, (err, msg) => {
-  console.log(msg.value.content)
-  // => { type: 'profile' }
-
-  // NOTE: only `content` is published (as usual)
 })
 ```
+
 
 private: 
 ```js
 const privateMsg = {
-  type: 'profile'
-  recps: ['@ye+QM09iPcDJD6YvQYjoQc7sLF/IFhmNbEqgdzQo3lQ=.ed25519']
+  content: {
+    type: 'profile'
+    recps: ['@ye+QM09iPcDJD6YvQYjoQc7sLF/IFhmNbEqgdzQo3lQ=.ed25519']
+  }
 }
 
-server.publish(privateMsg, (err, msg) => {
+server.db.create(privateMsg, (err, msg) => {
   console.log(msg.value.content)
   // => VayTFa.....yZ3Wqsg==.box
 
@@ -90,6 +81,21 @@ server.publish(privateMsg, (err, msg) => {
   // (in this example by ssb-private1, assuming that was installed)
 })
 ```
+
+NOTE that if you are using _classic_ `ssb-db`, the API behaves the same:
+
+```js
+const explicitPublicMsgDB1 = {
+  content: { type: 'profile' },
+  allowPublic: true
+}
+
+server.db.create(explicitPublicMsgDN!, (err, msg) => {
+  console.log(msg.value.content)
+  // => { type: 'profile' }
+})
+```
+
 
 ## Installation
 
@@ -118,13 +124,14 @@ where `allowedTypes` is an Array of message types which are allowed to be publis
 ## Explicit bypass
 
 Messages which would normally be blocked by the guard  bypass the guard by changing what's passed to the
-publish method to be of form `{ content, options: { allowPublic: true } }` 
+publish method to be of form `{ content, allowPublic: true }` 
 
 The `content` is what will be passed to the normal publish function.
 
 Design: this is deliberately verbose to avoid accidental publishing.
 It also has the benefit that if `ssb-guard-recps` isn't installed this publish will error because publish
 will expect the `type` to be in a different place.
+
 
 ## API
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const NotAllowedTypeError = (type) => new Error(
   `recps-guard: public messages of type "${type}" not allowed`
 )
 
+let warnings = 0
+
 module.exports = {
   name: 'recpsGuard',
   version: require('./package.json').version,
@@ -22,10 +24,14 @@ module.exports = {
     function publishHook (publish, args) {
       const [input, cb] = args
 
-      const isExplictAllow = (
-        input.allowPublic === true ||
-        get(input, ['options', 'allowPublic']) === true // legacy support
-      )
+      const modernAllow = input.allowPublic === true
+      const legacyAllow = get(input, ['options', 'allowPublic']) === true
+      if (legacyAllow && warnings < 5) {
+        console.trace('input.options.allowPublic is deprecated, please use input.allowPublic')
+        warnings++
+      }
+
+      const isExplictAllow = (modernAllow || legacyAllow)
 
       if (isExplictAllow) {
         const content = input.content

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "guards against unencrypted messages being accidentally published!",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/**/*.test.js | tap-spec"
+    "test": "npm run test:js && npm run lint",
+    "test:js": "tape test/**/*.test.js | tap-arc",
+    "lint": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -21,6 +23,9 @@
     "url": "https://github.com/ssbc/ssb-recps-guard/issues"
   },
   "homepage": "https://github.com/ssbc/ssb-recps-guard#readme",
+  "dependencies": {
+    "lodash.get": "^4.4.2"
+  },
   "devDependencies": {
     "scuttle-testbot": "^2.2.0",
     "ssb-box": "^1.0.1",
@@ -30,10 +35,8 @@
     "ssb-db2": "^8.1.0",
     "ssb-private1": "^1.0.1",
     "ssb-tribes": "^4.0.0",
-    "tap-spec": "^5.0.0",
+    "standard": "^17.1.0",
+    "tap-arc": "^1.2.2",
     "tape": "^5.7.2"
-  },
-  "dependencies": {
-    "lodash.get": "^4.4.2"
   }
 }

--- a/test/core-tests.js
+++ b/test/core-tests.js
@@ -1,39 +1,54 @@
-module.exports = (server, t, cb) => {
-  const msg = { type: 'profile' }
-  server.publish(msg, (err, data) => {
-    t.match(err.message, /recps-guard: public messages of type "profile" not allowed/, 'public blocked')
+const { promisify: p } = require('util')
 
-    const msg = { type: 'profile', recps: [server.id] }
-    server.publish(msg, (err, data) => {
-      t.error(err, 'msgs with recps allowed')
-      t.equal(typeof data.value.content, 'string', '(msg content encrypted)')
+module.exports = async (server, t, cb) => {
+  let description, content, input
 
-      const msg = Buffer.from('cats are cool').toString('base64') + '.box7'
-      server.publish(msg, (err, data) => {
-        t.error(err, 'pre-encrypted content published fine')
-        t.equal(typeof data.value.content, 'string', '(msg content encrypted)')
-
-        const content = { type: 'profile', name: 'mix' }
-        server.publish({ content, options: { allowPublic: true } }, (err, data) => {
-          if (err) return cb(err)
-          t.error(err, 'msgs { content, options: { allowPublic: true } allowed')
-          t.deepEqual(data.value.content, content, '(msg content unencrypted, allowPublic pruned)')
-
-          const weird = {
-            content: { type: 'profile', recps: [server.id] },
-            options: { allowPublic: true }
-          }
-          server.publish(weird, (err, data) => {
-            t.match(
-              err.message,
-              /recps-guard: should not have recps && allowPublic, check your code/,
-              'disallow recps AND allowPublic'
-            )
-
-            cb(null)
-          })
-        })
-      })
+  description = 'public blocked'
+  content = { type: 'profile' }
+  await p(server.publish)(content)
+    .then(() => t.fail(description))
+    .catch(err => {
+      t.match(err.message, /recps-guard: public messages of type "profile" not allowed/, description)
     })
-  })
+
+  description = 'msgs with recps allowed'
+  content = { type: 'profile', recps: [server.id] }
+  await p(server.publish)(content)
+    .then(data => t.equal(typeof data.value.content, 'string', description))
+    .catch(err => t.error(err, description))
+
+  description = 'pre-encrypted content published fine'
+  content = Buffer.from('cats are cool').toString('base64') + '.box7'
+  await p(server.publish)(content)
+    .then(data => t.equal(typeof data.value.content, 'string', description))
+    .catch(err => t.fail(err, description))
+
+  description = 'msgs { content, allowPublic: true } allowed'
+  content = { type: 'profile', name: 'mix' }
+  input = { content, allowPublic: true }
+  await p(server.publish)(input)
+    .then(data => t.deepEqual(data.value.content, content, description))
+    .catch(err => t.fail(err, description))
+
+  description = 'legacy: msgs { content, options: { allowPublic: true } }'
+  content = { type: 'profile', name: 'mix' }
+  input = { content, options: { allowPublic: true } }
+  await p(server.publish)(input)
+    .then(data => t.deepEqual(data.value.content, content, description))
+    .catch(err => t.fail(err, description))
+
+  description = 'disallow recps AND allowPublic'
+  input = {
+    content: { type: 'profile', recps: [server.id] },
+    allowPublic: true
+  }
+  await p(server.publish)(input)
+    .then(() => t.fail(description))
+    .catch(err => t.match(
+      err.message,
+      /recps-guard: should not have recps && allowPublic, check your code/,
+      'disallow recps AND allowPublic'
+    ))
+
+  cb(null)
 }

--- a/test/db2.test.js
+++ b/test/db2.test.js
@@ -33,7 +33,7 @@ test('db2', async t => {
       t.deepEqual(data.value.content, content, '(msg content unencrypted, allowPublic pruned). db.create')
     })
     .catch(err => {
-      t.error(err, 'msgs { content, options: { allowPublic: true } allowed. db.create')
+      t.error(err, 'msgs { content, { allowPublic: true } db.create')
     })
 
   const weird = {

--- a/test/db2.test.js
+++ b/test/db2.test.js
@@ -3,11 +3,11 @@ const test = require('tape')
 const Server = require('./test-bot')
 
 test('db2', async t => {
-  const server = Server({db1: false})
+  const server = Server({ db1: false })
   t.deepEqual(server.recpsGuard.allowedTypes(), [], 'recps.allowedTypes')
 
   let content = { type: 'profile' }
-  await p(server.db.create)({content})
+  await p(server.db.create)({ content })
     .then(msg => t.error(msg, "shouldn't get msg on err"))
     .catch((err) => {
       t.match(err.message, /recps-guard: public messages of type "profile" not allowed/, 'public blocked')
@@ -19,7 +19,7 @@ test('db2', async t => {
     })
 
   content = { type: 'profile', recps: [server.id] }
-  await p(server.db.create)({content})
+  await p(server.db.create)({ content })
     .then(data => {
       t.equal(typeof data.value.content, 'string', '(msg content encrypted)')
     })
@@ -55,7 +55,7 @@ test('db2', async t => {
 })
 
 test('can create a group', async t => {
-  const server = Server({db1: false})
+  const server = Server({ db1: false })
 
   const group = await p(server.tribes.create)({})
   t.equal(typeof group.groupId, 'string', 'created group with groupId')

--- a/test/install-order.test.js
+++ b/test/install-order.test.js
@@ -40,7 +40,7 @@ test('installed in right order', t => {
 test('installed in wrong order', { skip: true }, t => {
   t.plan(2) // goodHook + throw
 
-  var server
+  let server
   t.throws(
     () => {
        server = Server // eslint-disable-line

--- a/test/install-order.test.js
+++ b/test/install-order.test.js
@@ -24,7 +24,7 @@ test('installed in right order', t => {
 
   const input = {
     content,
-    options: { allowPublic: true }
+    allowPublic: true
   }
 
   server.publish(input, (err, msg) => {

--- a/test/not-installed.test.js
+++ b/test/not-installed.test.js
@@ -10,7 +10,7 @@ test('not installed', t => {
 
   const content = { type: 'profile' }
 
-  ssb.publish({ content, options: { allowPublic: true } }, (err) => {
+  ssb.publish({ content, allowPublic: true }, (err) => {
     t.match(err.message, /type must be a string/)
     ssb.close(t.end)
   })


### PR DESCRIPTION
This PR:
- :heavy_check_mark: change the DB1 allowPublic signature so that it's more like the DB2 one
- :heavy_check_mark: keeps support for the legacy DB1 signature
- :heavy_check_mark: adds linting
- :heavy_check_mark: does some refactoring to further simplify reading of code